### PR TITLE
add rspec for sshd_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,44 @@ source: [`docs/uml.md`](https://github.com/jumanjiman/wormhole/blob/master/docs/
 * Internal infrastructure should use appropriate access control mechanisms
   based on risk evaluation of the wormhole.
 
+RSpec documents key behaviors and assures no regressions:
+
+```
+jumanjiman/wormhole
+  image
+    should be available
+  config
+    should expose ssh port and only ssh port
+    should run sshd with logging
+
+sshd config
+  auth
+    should use privilege separation
+    should use pam
+    should allow pubkeyauthentication
+    should deny passwordauthentication
+    should deny gssapiauthentication
+    should deny kerberosauthentication
+    should deny challengeresponseauthentication
+  tunnels and forwarding
+    should deny ssh tunnels
+    should deny TCP forwarding
+    should deny X11 forwarding
+    should deny gateway ports
+  Common Configuration Enumeration (CCE)
+    CCE-3660-8 Disable remote ssh from accounts with empty passwords
+    CCE-3845-5 idle timeout interval should be set appropriately
+    CCE-4325-7 Disable SSH protocol version 1
+    CCE-4370-3 Disable SSH host-based authentication
+    CCE-4387-7 Disable root login via SSH
+    CCE-4431-3 SSH warning banner should be enabled
+    CCE-4475-0 Disable emulation of rsh command through sshd
+    CCE-14061-6 "keep alive" msg count should be set appropriately
+    CCE-14491-5 Use appropriate ciphers for SSH
+    CCE-14716-5 Users should not be allowed to set env options
+  obscurity
+    should hide patch level
+```
 
 
 ## User instructions

--- a/spec/wormhole/sshd_config_spec.rb
+++ b/spec/wormhole/sshd_config_spec.rb
@@ -1,0 +1,115 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'sshd config' do
+  before :all do
+    cmd = 'docker run --rm -i -t jumanjiman/wormhole sshd -T 2> /dev/null'
+    @config = %x(#{cmd})
+  end
+
+  describe 'auth' do
+    allow_auth = %W(
+      pubkeyauthentication
+    )
+
+    deny_auth = %W(
+      passwordauthentication
+      gssapiauthentication
+      kerberosauthentication
+      challengeresponseauthentication
+    )
+
+    it 'should use privilege separation' do
+      @config.should =~ /^useprivilegeseparation yes\r*$/
+    end
+
+    it 'should use pam' do
+      @config.should =~ /^usepam 1\r*$/
+    end
+
+    allow_auth.each do |allow|
+      it "should allow #{allow}" do
+        @config.should =~ /^#{allow} yes\r*$/
+      end
+    end
+
+    deny_auth.each do |deny|
+      it "should deny #{deny}" do
+        @config.should =~ /^#{deny} no\r*$/
+      end
+    end
+  end
+
+  describe 'tunnels and forwarding' do
+    it 'should deny ssh tunnels' do
+      @config.should =~ /^permittunnel no\r*$/
+    end
+
+    it 'should deny TCP forwarding' do
+      @config.should =~ /^allowtcpforwarding no\r*$/
+    end
+
+    # @note I could be convinced to allow X11 forwarding.
+    it 'should deny X11 forwarding' do
+      @config.should =~ /^x11forwarding no\r*$/
+    end
+
+    it 'should deny gateway ports' do
+      @config.should =~ /^gatewayports no\r*$/
+    end
+  end
+
+  describe 'Common Configuration Enumeration (CCE)' do
+    it 'CCE-3660-8 Disable remote ssh from accounts with empty passwords' do
+      @config.should =~ /^permitemptypasswords no\r*$/
+    end
+
+    it 'CCE-3845-5 idle timeout interval should be set appropriately' do
+      @config.should =~ /^clientaliveinterval 900\r*$/
+    end
+
+    it 'CCE-4325-7 Disable SSH protocol version 1' do
+      @config.should =~ /^protocol 2\r*$/
+      @config.should_not =~ /^protocol 1\r*$/
+    end
+
+    it 'CCE-4370-3 Disable SSH host-based authentication' do
+      @config.should =~ /^hostbasedauthentication no\r*$/
+    end
+
+    it 'CCE-4387-7 Disable root login via SSH' do
+      @config.should =~ /^permitrootlogin no\r*$/
+    end
+
+    it 'CCE-4431-3 SSH warning banner should be enabled' do
+      @config.should =~ %r{^banner /etc/issue\.net\r*$}
+    end
+
+    it 'CCE-4475-0 Disable emulation of rsh command through sshd' do
+      @config.should =~ /^ignorerhosts yes\r*$/
+    end
+
+    it 'CCE-14061-6 "keep alive" msg count should be set appropriately' do
+      @config.should =~ /^clientalivecountmax 0\r$/
+    end
+
+    it 'CCE-14491-5 Use appropriate ciphers for SSH' do
+      allowed_ciphers = %W(
+        aes128-ctr
+        aes192-ctr
+        aes256-ctr
+      )
+      @config.should =~ /^ciphers #{allowed_ciphers.join(',')}\r*$/
+    end
+
+    it 'CCE-14716-5 Users should not be allowed to set env options' do
+      @config.should =~ /^permituserenvironment no\r*$/
+    end
+  end
+
+  describe 'obscurity' do
+    it 'should hide patch level' do
+      @config.should =~ /^showpatchlevel no\r*$/
+    end
+  end
+end

--- a/wormhole/sshd_config
+++ b/wormhole/sshd_config
@@ -224,7 +224,7 @@ ClientAliveInterval 900
 #
 # Recommended by CCE: 0
 #
-ClientAliveCountMax 3
+ClientAliveCountMax 0
 
 
 


### PR DESCRIPTION
On the one hand, this rspec simply repeats the sshd config (bleh),
but on the other hand it provides documentation (included in README)
to clearly explain the restrictions on sshd.
