### PR TITLE
remove cron-related packages and add rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ jumanjiman/wormhole
     should run sshd with logging
     should have volume /home/user
     should have volume /media/state/etc/ssh
-  packages
+  prohibited packages
+    should not have at installed
     should not have sudo installed
+  prohibited commands
+    should not have the at command
+    should not have the crond command
+    should not have the crontab command
   user convenience
     man -k returns results
     locate returns the path for issue.net

--- a/spec/wormhole/dockerfile_spec.rb
+++ b/spec/wormhole/dockerfile_spec.rb
@@ -46,8 +46,9 @@ describe 'jumanjiman/wormhole' do
     end
   end
 
-  describe 'packages' do
+  describe 'prohibited packages' do
     prohibited_packages = %W(
+      at
       sudo
     )
 
@@ -56,6 +57,25 @@ describe 'jumanjiman/wormhole' do
         dr = 'docker run --rm -i -t jumanjiman/wormhole'
         output = %x(#{dr} rpm -q #{package} 2> /dev/null).split($RS)
         output[0].chomp.should =~ /^package #{package} is not installed$/
+      end
+    end
+  end
+
+  # Multiple packages can provide some commands, so
+  # we check for the commands, too.
+  # Multiple CCE's recommend restricting at and cron.
+  describe 'prohibited commands' do
+    prohibited_commands = %W(
+      at
+      crond
+      crontab
+    )
+
+    prohibited_commands.each do |cmd|
+      it "should not have the #{cmd} command" do
+        dr = "docker run --rm -i -t jumanjiman/wormhole which #{cmd}"
+        output = %x(#{dr} 2> /dev/null).split($RS)
+        output[0].chomp.should =~ /no #{cmd} in/
       end
     end
   end

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -5,7 +5,10 @@ FROM mattdm/fedora:f20
 MAINTAINER Paul Morgan <jumanjiman@gmail.com>
 
 # Work around https://bugzilla.redhat.com/show_bug.cgi?id=1066983
-RUN yum remove -y vim-minimal sudo
+# and remove prohibited packages.
+RUN yum remove -y vim-minimal \
+    at \
+    sudo
 
 # Install dependencies.
 RUN yum install -y \
@@ -31,6 +34,11 @@ RUN yum clean all
 
 # Break su for everybody but root.
 ADD su /etc/pam.d/
+
+# Break cron for everybody.
+ADD cron.allow /etc/
+RUN chmod 0400 /usr/bin/crontab
+RUN chmod 0400 /usr/sbin/crond
 
 # Populate /etc/skel
 ADD .bashrc /etc/skel/

--- a/wormhole/cron.allow
+++ b/wormhole/cron.allow
@@ -1,0 +1,30 @@
+# @see crontab(1)
+#
+# The format of this file is a list of usernames, one on each line.
+# Whitespace is not permitted.
+#
+# * The superuser may ALWAYS use at and cron.
+#
+# * If /etc/cron.allow exists, user must be in the file
+#   in order to be allowed to use the cron command.
+#
+# SNAC LinuxGuide:
+#   3.4
+#   3.4.2
+#   3.4.3
+#
+# CCERef#:
+#   CCE-4304-2, CCE-3833-1, CCE-3604-6, CCE-3626-9, CCE-4022-0
+#   CCE-3851-3, CCE-3481-9, CCE-4322-4, CCE-4203-6, CCE-4379-4
+#   CCE-4054-3, CCE-4441-2, CCE-4250-7, CCE-4331-5, CCE-4106-1
+#   CCE-4450-3, CCE-4388-5, CCE-3983-4, CCE-4380-2, CCE-4212-7,
+#   CCE-4251-5
+#
+# SNAC GuideSection 3.4.2 states:
+#   Cron and anacron make use of a number of configuration
+#   files and directories. The system crontabs need only be edited
+#   by root, and user crontabs are edited using the setuid root
+#   crontab command. If unprivileged users can modify system
+#   cron configuration files, they may be able to gain elevated
+#   privileges, so all unnecessary access to these files should
+#   be disabled.


### PR DESCRIPTION
We don't want users trying to add cron or at jobs in devenv.

CCERef#:
CCE-4324-0
CCE-4304-2, CCE-3833-1, CCE-3604-6, CCE-3626-9, CCE-4022-0
CCE-3851-3, CCE-3481-9, CCE-4322-4, CCE-4203-6, CCE-4379-4
CCE-4054-3, CCE-4441-2, CCE-4250-7, CCE-4331-5, CCE-4106-1
CCE-4450-3, CCE-4388-5, CCE-3983-4, CCE-4380-2, CCE-4212-7,
CCE-4251-5
