### PR TITLE
work around BZ1099206 (go get is broken on fresh install)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+---
+
+# Avoid diff-churn!
+Style/TrailingComma:
+  EnforcedStyleForMultiline: comma

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,15 @@ a [topic branch](http://progit.org/book/ch3-4.html) of your fork.
    ```
 
 
+Diff churn
+----------
+
+Please minimize diff churn to enhance git history commands.
+
+* Arrays should usually be multi-line with trailing commas.
+
+Update `.rubocop.yml` if necessary to favor minimal churn.
+
 
 Linear history
 --------------

--- a/spec/wormhole/dockerfile_spec.rb
+++ b/spec/wormhole/dockerfile_spec.rb
@@ -105,4 +105,17 @@ describe 'jumanjiman/wormhole' do
       output.should =~ %r{^/usr/local/Eiffel.*/bin/estudio$}
     end
   end
+
+  # https://github.com/jumanjiman/bz1099206
+  describe 'BZ1099206' do
+    it 'go get should work' do
+      dr = 'docker run --rm -i -t -u user jumanjiman/wormhole bash -c'
+      go_cmd = [
+        'export GOPATH=/home/user/gocode',
+        'mkdir -p /home/user/bin',
+        'go get github.com/epeli/hooktftp',
+      ].join(';')
+      system("#{dr} \"#{go_cmd}\"").should be_truthy
+    end
+  end
 end

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -39,6 +39,9 @@ RUN yum install -y \
     git-hg \
     ; yum clean all
 
+# https://github.com/jumanjiman/bz1099206
+RUN yum -y reinstall golang golang-pkg* golang-src
+
 # Break su for everybody but root.
 ADD su /etc/pam.d/
 


### PR DESCRIPTION
Fedora golang packages are broken on fresh install
and must be reinstalled for `go get` to work.

On a fresh installation of Fedora 20 with `golang-1.2.2-7.fc20.x86_64`
or Fedora Rawhide with `golang-1.3rc1-1.fc21.x86_64`,
`go get` errors out with:

```
go install runtime/cgo: open /usr/lib/golang/pkg/linux_amd64/runtime/cgo.a: permission denied
```

If you run `yum -y reinstall golang golang-pkg* golang-src`,
the `go get` command finishes successfully.
One should not have to reinstall the packages to get a working set.

See https://github.com/jumanjiman/bz1099206 for reproducer.
