### PR TITLE
add open-scap security checks to test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,20 @@ RSpec documents key behaviors and assures no regressions:
     ldc D compiler
       compiles a D program
 
+    SCAP security checks (slow test)
+      should pass all tests
+      /etc/securetty should be a zero-size file
+
     prohibited packages
       should not have at installed
+      should not have prelink installed
       should not have sudo installed
 
     prohibited commands
       should not have the at command
       should not have the crond command
       should not have the crontab command
+      should not have the /usr/sbin/prelink command
 
     sshd config
       auth
@@ -154,8 +160,82 @@ RSpec documents key behaviors and assures no regressions:
       su
         "user" cannot su
 
-    Finished in 53.16 seconds (files took 0.43034 seconds to load)
-    55 examples, 0 failures
+    Finished in 1 minute 6.35 seconds (files took 0.45472 seconds to load)
+    61 examples, 0 failures
+
+
+The OpenSCAP test shown above uses a
+[tailoring file](wormhole/wormhole-devenv-xccdf.xml)
+to adjust the upstream checks.
+It expands to this inside the container:
+
+    Title   gpgcheck Enabled In Main Yum Configuration
+    Rule    ensure_gpgcheck_globally_activated
+    Result  pass
+
+    Title   gpgcheck Enabled For All Yum Package Repositories
+    Rule    ensure_gpgcheck_never_disabled
+    Result  pass
+
+    Title   Shared Library Files Have Restrictive Permissions
+    Rule    file_permissions_library_dirs
+    Result  pass
+
+    Title   Shared Library Files Have Root Ownership
+    Rule    file_ownership_library_dirs
+    Result  pass
+
+    Title   System Executables Have Restrictive Permissions
+    Rule    file_permissions_binary_dirs
+    Result  pass
+
+    Title   System Executables Have Root Ownership
+    Rule    file_ownership_binary_dirs
+    Result  pass
+
+    Title   Direct root Logins Not Allowed
+    Rule    no_direct_root_logins
+    Result  notchecked
+
+    Title   Virtual Console Root Logins Restricted
+    Rule    securetty_root_login_console_only
+    Result  pass
+
+    Title   Serial Port Root Logins Restricted
+    Rule    restrict_serial_port_logins
+    Result  pass
+
+    Title   Only Root Has UID 0
+    Rule    no_uidzero_except_root
+    Result  pass
+
+    Title   Log In to Accounts With Empty Password Impossible
+    Rule    no_empty_passwords
+    Result  pass
+
+    Title   Password Hashes For Each Account Shadowed
+    Rule    no_hashes_outside_shadow
+    Result  pass
+
+    Title   netrc Files Do Not Exist
+    Rule    no_netrc_files
+    Result  pass
+
+    Title   SSH Root Login Disabled
+    Rule    sshd_disable_root_login
+    Result  pass
+
+    Title   SSH Access via Empty Passwords Disabled
+    Rule    sshd_disable_empty_passwords
+    Result  pass
+
+    Title   SSH Idle Timeout Interval Used
+    Rule    sshd_set_idle_timeout
+    Result  pass
+
+    Title   SSH Client Alive Count Used
+    Rule    sshd_set_keepalive
+    Result  pass
 
 
 ## User instructions

--- a/spec/functional/oscap_spec.rb
+++ b/spec/functional/oscap_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'SCAP security checks (slow test)' do
+  it 'should pass all tests' do
+    cmds = '
+      cd /usr/share/xml/scap/ssg/fedora/
+      oscap xccdf eval --profile xccdf_wormhole_profile_devenv \
+        --tailoring-file wormhole-devenv-xccdf.xml \
+        --cpe ssg-fedora-cpe-dictionary.xml \
+        ssg-fedora-xccdf.xml && echo OK
+    '
+    ssh(cmds).should match(/^OK$/)
+  end
+
+  # Why does oscap skip this check?
+  it '/etc/securetty should be a zero-size file' do
+    cmd = "stat --format='%s' /etc/securetty"
+    ssh(cmd).should match(/^0$/)
+  end
+end

--- a/spec/functional/prohibited_packages_spec.rb
+++ b/spec/functional/prohibited_packages_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 describe 'prohibited packages' do
   prohibited_packages = %w(
     at
+    prelink
     sudo
   )
 
@@ -23,11 +24,15 @@ describe 'prohibited commands' do
     at
     crond
     crontab
+    /usr/sbin/prelink
   )
 
   prohibited_commands.each do |cmd|
     it "should not have the #{cmd} command" do
       output = ssh("which #{cmd} 2>&1")
+      # `which' splits the cmd into path and basename components,
+      # such as `which: no prelink in (/usr/sbin)'
+      cmd = cmd.split('/').last
       output.should =~ /no #{cmd} in/
     end
   end

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -44,6 +44,7 @@ RUN yum install -y \
     python3-devel python3-nose python3-setuptools python3-pep8 rpm-python3 \
     pylint python3-pylint \
     rpm-build libxslt createrepo git-annex \
+    scap-security-guide \
     strace \
     tmux tmux-powerline reptyr \
     golang golang-docs golang-cover golang-github-coreos-go-systemd-devel \
@@ -106,6 +107,8 @@ ADD sshd /etc/pam.d/
 ADD password-auth /etc/pam.d/
 ADD password-auth.patch /etc/pam.d/
 ADD start.sh /usr/sbin/
+ADD wormhole-devenv-xccdf.xml /usr/share/xml/scap/ssg/fedora/
+ADD oscap-remediate.sh /usr/sbin/
 
 # Install arcanist.
 # https://secure.phabricator.com/book/phabricator/article/arcanist/
@@ -115,6 +118,9 @@ RUN /usr/local/sbin/install-arc.sh
 # Update system databases for user convenience.
 RUN mandb &> /dev/null
 RUN updatedb &> /dev/null
+
+# Remediate security after all packages are installed.
+RUN /usr/sbin/oscap-remediate.sh
 
 EXPOSE 22
 ENV LANG C

--- a/wormhole/oscap-remediate.sh
+++ b/wormhole/oscap-remediate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+dirs="
+/lib64
+/usr/lib
+/usr/lib64
+/usr/bin
+/usr/local/bin
+/sbin
+/usr/sbin
+/usr/local/sbin
+"
+for dir in $dirs; do
+  # If any file has group or world write privilege, remove that privilege.
+  find $dir -type f -perm /go=w -exec chmod go-w {} +
+done
+
+# Disable direct root login on any terminal.
+> /etc/securetty
+
+# Enable "user" to read this file since we run oscap as "user".
+# If "user" cannot read the file, the oscap check errors out.
+chmod 0444 /etc/securetty
+
+# Disable empty password support from PAM.
+sed -r -i 's/\<nullok\>//g' /etc/pam.d/*

--- a/wormhole/password-auth
+++ b/wormhole/password-auth
@@ -1,11 +1,11 @@
 auth        required      pam_env.so
-auth        sufficient    pam_unix.so try_first_pass nullok
+auth        sufficient    pam_unix.so try_first_pass
 auth        required      pam_deny.so
 
 account     required      pam_unix.so
 
 password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
-password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow
+password    sufficient    pam_unix.so try_first_pass use_authtok sha512 shadow
 password    required      pam_deny.so
 
 session     optional      pam_keyinit.so revoke

--- a/wormhole/password-auth.patch
+++ b/wormhole/password-auth.patch
@@ -1,6 +1,6 @@
 --- password-auth.orig	2014-06-22 17:33:54.279000000 -0400
 +++ password-auth	2014-06-22 17:33:42.138000000 -0400
 @@ -2 +2,2 @@
--auth        sufficient    pam_unix.so try_first_pass nullok
-+auth        requisite     pam_unix.so try_first_pass nullok
+-auth        sufficient    pam_unix.so try_first_pass
++auth        requisite     pam_unix.so try_first_pass
 +auth        sufficient    pam_duo.so

--- a/wormhole/wormhole-devenv-xccdf.xml
+++ b/wormhole/wormhole-devenv-xccdf.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Thanks to http://martin.preisler.me/2013/11/xccdf-tailoring/ -->
+<Tailoring xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.open-scap_tailoring_example">
+  <status>incomplete</status>
+  <version time="2014-07-05T13:00:15.000-04:00">0.0.1</version>
+  <Profile id="xccdf_wormhole_profile_devenv" extends="common">
+    <title xml:lang="en-US">Tailoring file for Fedora common profile</title>
+    <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">This profile adjusts the common profile for wormhole devenv containers</description>
+    <!--
+        We don't even have prelink package, so the upstream check
+        for its configuration is defective. However, we still want
+        to prevent prelink, so we have separate rspec to check that
+        prelink is not installed.
+    -->
+    <select idref="disable_prelink" selected="false"/>
+
+    <!--
+        I don't know why oscap skips this test.
+        I still want to check that /etc/securetty is zero-length,
+        so we have an rspec check for it.
+    -->
+    <select idref="no_direct_root_logins" selected="true"/>
+
+    <!--
+        We disable password as an authentication mechanism altogether.
+        Therefore we don't bother with the default password settings.
+    -->
+    <select idref="accounts_password_minlen_login_defs" selected="false"/>
+    <select idref="accounts_minimum_age_login_defs" selected="false"/>
+    <select idref="accounts_maximum_age_login_defs" selected="false"/>
+    <select idref="accounts_password_warn_age_login_defs" selected="false"/>
+
+    <!--
+        It does not make sense to run ntpd inside a container, so
+        we disable this check.
+    -->
+    <select idref="service_ntpd_enabled" selected="false"/>
+    <select idref="ntpd_specify_remote_server" selected="false"/>
+
+    <!--
+        Upstream checks for a 5-minute idle timeout, but
+        we currently allow a 15-minute idle timeout.
+    -->
+    <refine-value idref="sshd_idle_timeout_value" selector="15_minutes"/>
+  </Profile>
+</Tailoring>


### PR DESCRIPTION
- add sqlite-devel to devenv to enable sqlite3 ruby gem
- ensure devenv passes all open-scap tests in common profile
