### PR TITLE
add tool to look for bashisms in shell scripts

### DIFF
--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -24,6 +24,7 @@ RUN yum install -y \
     asciinema \
     bind-utils \
     bc \
+    devscripts-minimal \
     dictd \
     diction \
     ftp tftp \


### PR DESCRIPTION
We have a long-standing policy to use `#!/bin/bash` when a script
contains bash-specific syntax. However, we have never implemented
a unit test for it. We simply trust people to use the correct shebang.

Arch Linux wiki suggests:

```
checkbashisms -f -p $(grep -rlE '^#! ?/bin/(env )?sh' /usr/bin)
```

checkbashisms is part of devscripts-minimal in Fedora.

Resolves https://github.com/jumanjiman/wormhole/issues/39

Related: Debian provides https://packages.debian.org/sid/devscripts
which we may want to use to test our in-house puppet and rpm repos
to assure compliance.
