### PR TITLE
deployment takes more than the default 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ the image on any update. https://github.com/jumanjiman/docker-gocd may be
 a candidate for the solution.
 
 
-## Test harness
+## Test harness [![wercker status](https://app.wercker.com/status/690a6e04aec0e9829f88dd26c8fae27f/s/master "wercker status")](https://app.wercker.com/project/bykey/690a6e04aec0e9829f88dd26c8fae27f)
 
 RSpec documents key behaviors and assures no regressions:
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,5 @@
 box: wercker-labs/docker
+no-response-timeout: 20
 build:
   steps:
     - install-packages:


### PR DESCRIPTION
wercker steps time out after 5 minutes by default.
http://devcenter.wercker.com/articles/werckeryml/

However, `docker push jumanjiman/wormhole` takes more
than that. Therefore bump the timeout for wercker steps.
Too bad this is a global setting according to the doc
referenced above. I'd prefer to only bump the step timeout
for deployment, but I'll take what I can get.