### PR TITLE
wormhole:  Add go distribution

### DIFF
--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -50,6 +50,7 @@ RUN yum install -y \
     git-svn \
     make \
     jwhois \
+    go \
     ; yum clean all
 
 # Break su for everybody but root.


### PR DESCRIPTION
Go Distribution is required to build rpm package for the
logstash-forwarder.  This commit is intended to give wormhole
environment the go packages in order to properly build out the
binaries.

http://golang.org/doc/install

https://github.com/elasticsearch/logstash-forwarder