### PR TITLE
install latest docker client in system path

### DIFF
--- a/spec/functional/commands_spec.rb
+++ b/spec/functional/commands_spec.rb
@@ -2,9 +2,10 @@
 require 'spec_helper'
 
 describe 'useful commands' do
-  commands = [
-    'wget',
-  ]
+  commands = %w(
+    docker
+    wget
+  )
 
   commands.each do |cmd|
     it '${cmd} is in user path' do

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -149,6 +149,10 @@ RUN useradd user
 # Ugly workaround. Really ugly.
 RUN usermod -aG slocate user
 
+# Install latest docker client.
+RUN curl -sS -L -o /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-latest ;\
+    chmod 0755 /usr/bin/docker
+
 # Do not track changes in volumes.
 VOLUME ["/home/user", "/media/state/etc/ssh"]
 


### PR DESCRIPTION
This lets the unprivileged user specify the `-H` option
and interact with docker hosts that have the remote API enabled.